### PR TITLE
Fix: error converting yaml: line 14: mapping values are not allowed

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   PAPERMERGE_DATABASE_HOST: {{ .Values.global.conf.db.host | quote }}
   PAPERMERGE_REDIS_HOST: {{ .Values.global.conf.redis.host | quote }}
   PAPERMERGE_MEDIA_DIR: {{ .Values.global.conf.app.media_dir }}
-{{- if .Values.global.conf.es.enabled -}}
+{{- if .Values.global.conf.es.enabled }}
   PAPERMERGE_ELASTICSEARCH_HOSTS: {{ .Values.global.conf.es.hosts | quote }}
   PAPERMERGE_ELASTICSEARCH_PORT: {{ .Values.global.conf.es.port | quote }}
 {{- end}}


### PR DESCRIPTION
### Fixing error:
`  [debug] error converting YAML to JSON: yaml: line 14: mapping values are not allowed in this context`

### How to reproduce
Enable Elastic Search in helm chart values.yaml
```
global:
  conf:
    es:
      enabled: true
      hosts: "papermerge-es-elasticsearch-coordinating-only"
      port: 9200
```

### The Output before:
```
  PAPERMERGE_DATABASE_HOST: "papermerge-db-primary"
  PAPERMERGE_REDIS_HOST: "papermerge-redis-master"
  PAPERMERGE_MEDIA_DIR: /data/mediaPAPERMERGE_ELASTICSEARCH_HOSTS: "papermerge-es-elasticsearch-coordinating-only"
  PAPERMERGE_ELASTICSEARCH_PORT:
```

### The Output after that change:
```
  PAPERMERGE_DATABASE_HOST: "papermerge-db-primary"
  PAPERMERGE_REDIS_HOST: "papermerge-redis-master"
  PAPERMERGE_MEDIA_DIR: /data/media
  PAPERMERGE_ELASTICSEARCH_HOSTS: "papermerge-es-elasticsearch-coordinating-only"
  PAPERMERGE_ELASTICSEARCH_PORT:
```